### PR TITLE
Remove unsupported caching from journal table

### DIFF
--- a/app.R
+++ b/app.R
@@ -227,7 +227,7 @@ server <- function(input, output, session) {
   # ---- Journal (initial render) ----
   output$log_table <- DT::renderDataTable({
     DT::datatable(log_data(), options = list(pageLength = 10))
-  }) %>% bindCache(log_data())
+  })
   
   # ---- Cleanup ----
   onStop(function() db_engine$disconnect())


### PR DESCRIPTION
## Summary
- Fix shiny app startup error by removing `bindCache` call from `DT::renderDataTable` output.

## Testing
- `Rscript --vanilla test_decision.R` *(skipped: R6 package not installed)*
- `Rscript --vanilla test_checklist.R` *(skipped: R6 package not installed)*
- `Rscript --vanilla test_db.R` *(skipped: R6 package not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c050d15b30832a82279c2a14fbf06a