### PR TITLE
Display human-readable scenario names

### DIFF
--- a/app.R
+++ b/app.R
@@ -21,6 +21,23 @@ library(magrittr)
 # ---- Helpers ------------------------------------------------------------------
 `%||%` <- function(x, y) if (is.null(x)) y else x
 
+pretty_scenario <- function(code) {
+  if (is.null(code) || is.na(code) || !nzchar(code)) return("—")
+  prefix <- substr(code, 1, 2)
+  prefix_name <- switch(prefix,
+    TL = "Trending Long",
+    TS = "Trending Short",
+    SL = "Sideways Long",
+    SS = "Sideways Short",
+    prefix
+  )
+  rest <- substr(code, 4, nchar(code))
+  if (!nzchar(rest)) return(prefix_name)
+  rest <- gsub("_", " ", rest, fixed = TRUE)
+  rest <- tools::toTitleCase(tolower(rest))
+  paste(prefix_name, rest, sep = " - ")
+}
+
 # ---- Modules ------------------------------------------------------------------
 # These files must exist: R/decision_module.R, R/checklist_module.R, R/db_module.R
 source("R/decision_module.R", local = TRUE)
@@ -138,7 +155,7 @@ server <- function(input, output, session) {
     # 3) Outputs (UI)
     output$decision_ui <- renderUI({
       tagList(
-        p(strong("Scenario: "), dec$scenario %||% "—"),
+        p(strong("Scenario: "), pretty_scenario(dec$scenario)),
         p(strong("Eligible: "), if (isTRUE(dec$eligible)) "Yes" else "No"),
         render_reasons(dec$reasons)
       )
@@ -226,8 +243,12 @@ server <- function(input, output, session) {
 
   # ---- Journal (initial render) ----
   output$log_table <- DT::renderDataTable({
-    DT::datatable(log_data(), options = list(pageLength = 10))
-  }) %>% bindCache(log_data())
+    df <- log_data()
+    if (!is.null(df) && "scenario" %in% names(df)) {
+      df$scenario <- vapply(df$scenario, pretty_scenario, character(1))
+    }
+    DT::datatable(df, options = list(pageLength = 10))
+  })
   
   # ---- Cleanup ----
   onStop(function() db_engine$disconnect())


### PR DESCRIPTION
## Summary
- Fix shiny app startup error by removing `bindCache` call from `DT::renderDataTable`.
- Convert scenario codes to human-friendly labels in decision output and journal.

## Testing
- `Rscript --vanilla test_decision.R`
- `Rscript --vanilla test_checklist.R`
- `Rscript --vanilla test_db.R` *(skipped: duckdb package not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c050d15b30832a82279c2a14fbf06a