### PR TITLE
Add journal download buttons for CSV and Excel

### DIFF
--- a/app.R
+++ b/app.R
@@ -107,7 +107,12 @@ ui <- page_sidebar(
     h3("Journal"),
     div(
       actionButton("clear_log", "Clear Journal", class = "btn-danger mb-2"),
-      DT::dataTableOutput("log_table")
+      DT::dataTableOutput("log_table"),
+      div(
+        class = "mt-2",
+        downloadButton("download_log_csv", "Download CSV"),
+        downloadButton("download_log_xlsx", "Download Excel", class = "ms-2")
+      )
     )
   )
 )
@@ -260,6 +265,28 @@ server <- function(input, output, session) {
     DT::datatable(df, options = list(pageLength = 10))
     DT::datatable(log_data(), options = list(pageLength = 10))
   })
+
+  output$download_log_csv <- downloadHandler(
+    filename = function() paste0("journal-", Sys.Date(), ".csv"),
+    content = function(file) {
+      df <- log_data()
+      if (!is.null(df) && "scenario" %in% names(df)) {
+        df$scenario <- vapply(df$scenario, pretty_scenario, character(1))
+      }
+      write.csv(df, file, row.names = FALSE)
+    }
+  )
+
+  output$download_log_xlsx <- downloadHandler(
+    filename = function() paste0("journal-", Sys.Date(), ".xlsx"),
+    content = function(file) {
+      df <- log_data()
+      if (!is.null(df) && "scenario" %in% names(df)) {
+        df$scenario <- vapply(df$scenario, pretty_scenario, character(1))
+      }
+      writexl::write_xlsx(df, file)
+    }
+  )
   
   # ---- Cleanup ----
   onStop(function() db_engine$disconnect())


### PR DESCRIPTION
## Summary
- Allow users to download journal entries in CSV or Excel formats
- Expose dedicated download buttons beneath the journal table

## Testing
- `Rscript test_decision.R` *(fails: R6 package not installed)*
- `Rscript test_checklist.R` *(fails: R6 package not installed)*
- `Rscript test_db.R` *(fails: R6 package not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6643ea69c832a8482cda83d0cb9b5