### PR TITLE
Add journal download buttons for CSV and Excel

### DIFF
--- a/app.R
+++ b/app.R
@@ -17,6 +17,7 @@ library(DBI)
 library(DT)
 library(memoise)
 library(magrittr)
+library(writexl)
 
 # ---- Helpers ------------------------------------------------------------------
 `%||%` <- function(x, y) if (is.null(x)) y else x
@@ -107,7 +108,12 @@ ui <- page_sidebar(
     h3("Journal"),
     div(
       actionButton("clear_log", "Clear Journal", class = "btn-danger mb-2"),
-      DT::dataTableOutput("log_table")
+      DT::dataTableOutput("log_table"),
+      div(
+        class = "mt-2",
+        downloadButton("download_log_csv", "Download CSV"),
+        downloadButton("download_log_xlsx", "Download Excel", class = "ms-2")
+      )
     )
   )
 )
@@ -258,8 +264,29 @@ server <- function(input, output, session) {
       df$scenario <- vapply(df$scenario, pretty_scenario, character(1))
     }
     DT::datatable(df, options = list(pageLength = 10))
-    DT::datatable(log_data(), options = list(pageLength = 10))
   })
+
+  output$download_log_csv <- downloadHandler(
+    filename = function() paste0("journal-", Sys.Date(), ".csv"),
+    content = function(file) {
+      df <- log_data()
+      if (!is.null(df) && "scenario" %in% names(df)) {
+        df$scenario <- vapply(df$scenario, pretty_scenario, character(1))
+      }
+      write.csv(df, file, row.names = FALSE)
+    }
+  )
+
+  output$download_log_xlsx <- downloadHandler(
+    filename = function() paste0("journal-", Sys.Date(), ".xlsx"),
+    content = function(file) {
+      df <- log_data()
+      if (!is.null(df) && "scenario" %in% names(df)) {
+        df$scenario <- vapply(df$scenario, pretty_scenario, character(1))
+      }
+      write_xlsx(df, file)
+    }
+  )
   
   # ---- Cleanup ----
   onStop(function() db_engine$disconnect())


### PR DESCRIPTION
## Summary
- Allow users to download journal entries in CSV or Excel formats
- Expose dedicated download buttons beneath the journal table
- Load writexl and streamline log rendering for reliable Excel exports

## Testing
- `Rscript --vanilla test_decision.R`
- `Rscript --vanilla test_checklist.R`
- `Rscript --vanilla test_db.R` *(skipped: duckdb package not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6643ea69c832a8482cda83d0cb9b5