### PR TITLE
Replace Multi-TF tab with Decision Pairs evaluation

### DIFF
--- a/R/decision_module.R
+++ b/R/decision_module.R
@@ -55,7 +55,7 @@ DecisionModule <- R6::R6Class(
     #' @inheritParams DecisionModule
     determine = function(regime, side, htf_dir, itf_dir,
                          htf_trend, itf_trend,
-                         curve, confluence = TRUE) {
+                         curve, confluence = TRUE, ath_atl = NULL) {
       reasons <- character()
       scenario <- NA_character_
       eligible <- TRUE


### PR DESCRIPTION
## Summary
- replace the prior multi-timeframe tab with the new Decision Pairs interface, editable snapshot grid, and results table
- add validation helpers for the fixed timeframe trios and pass ATH/ATL context to the decision engine
- extend the decision module signature to accept optional ATH/ATL metadata and harden the `%||%` helper for empty inputs

## Testing
- Not run (Rscript not available in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e21881833c832abe99c7197d4319a0